### PR TITLE
fix(positioning): performance optimisation on typeahead and datepicker

### DIFF
--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -24,10 +24,12 @@ import {DOCUMENT} from '@angular/common';
 
 import {listenToTriggers} from '../util/triggers';
 import {ngbAutoClose} from '../util/autoclose';
+import {ngbWindowResize} from '../util/resize';
 import {positionElements, PlacementArray} from '../util/positioning';
 import {PopupService} from '../util/popup';
 
 import {NgbTooltipConfig} from './tooltip-config';
+import {take} from 'rxjs/operators';
 
 let nextId = 0;
 
@@ -134,13 +136,12 @@ export class NgbTooltip implements OnInit, OnDestroy {
   private _popupService: PopupService<NgbTooltipWindow>;
   private _windowRef: ComponentRef<NgbTooltipWindow>;
   private _unregisterListenersFn;
-  private _zoneSubscription: any;
 
   constructor(
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbTooltipConfig,
       private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _changeDetector: ChangeDetectorRef,
-      private _applicationRef: ApplicationRef) {
+      _applicationRef: ApplicationRef) {
     this.autoClose = config.autoClose;
     this.placement = config.placement;
     this.triggers = config.triggers;
@@ -151,14 +152,6 @@ export class NgbTooltip implements OnInit, OnDestroy {
     this.closeDelay = config.closeDelay;
     this._popupService = new PopupService<NgbTooltipWindow>(
         NgbTooltipWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, _applicationRef);
-
-    this._zoneSubscription = _ngZone.onStable.subscribe(() => {
-      if (this._windowRef) {
-        positionElements(
-            this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
-            this.container === 'body', 'bs-tooltip');
-      }
-    });
   }
 
   /**
@@ -192,7 +185,10 @@ export class NgbTooltip implements OnInit, OnDestroy {
 
       if (this.container === 'body') {
         this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
+        ngbWindowResize(this._ngZone, () => this.position(), this.hidden);
       }
+
+      this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => this.position());
 
       // We need to detect changes, because we don't know where .open() might be called from.
       // Ex. opening tooltip from one of lifecycle hooks that run after the CD
@@ -260,6 +256,16 @@ export class NgbTooltip implements OnInit, OnDestroy {
     if (this._unregisterListenersFn) {
       this._unregisterListenersFn();
     }
-    this._zoneSubscription.unsubscribe();
+  }
+
+  /**
+   * Trigger a repositioning of the tooltip
+   */
+  position() {
+    if (this._windowRef) {
+      positionElements(
+          this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
+          this.container === 'body', 'bs-tooltip');
+    }
   }
 }

--- a/src/util/resize.ts
+++ b/src/util/resize.ts
@@ -1,0 +1,10 @@
+import {NgZone} from '@angular/core';
+import {fromEvent, Observable} from 'rxjs';
+import {takeUntil, throttleTime} from 'rxjs/operators';
+
+
+export function ngbWindowResize(zone: NgZone, callback: () => void, unsubscribe$: Observable<any>) {
+  zone.runOutsideAngular(() => {
+    fromEvent(window, 'resize').pipe(takeUntil(unsubscribe$), throttleTime(10)).subscribe(() => callback());
+  });
+}


### PR DESCRIPTION
Thank you for spotting this issue out.

I further applied those changes you proposed to `typeahead` and `datepicker`, and gain a great performance boost in my application under IE 11.